### PR TITLE
Feature reorder script includes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-html",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "generate html for mocha browser test.",
   "repository": {
     "type": "git",

--- a/template/runner.html.ejs
+++ b/template/runner.html.ejs
@@ -8,13 +8,14 @@
 
 <div id="mocha"></div>
 
-<!-- js src -->
-<% srcPaths.forEach(function (path) {  %><script src="<%= path %>"></script>
-<% }); %>
 <!-- mocha and assert module -->
 <script src="<%= assertPath %>"></script>
 <script src="<%= mochaPath %>"></script>
 <script>mocha.setup('bdd')</script>
+
+<!-- js src -->
+<% srcPaths.forEach(function (path) {  %><script src="<%= path %>"></script>
+<% }); %>
 
 <!-- test codes -->
 <% testPaths.forEach(function (path) {  %><script src="<%= path %>"></script>


### PR DESCRIPTION
I was unable to include the sinon-chai library in the src array because the chai and mocha scripts are included in the template afterwards.  This is just a minor reordering to facilitate other test tool libraries.
